### PR TITLE
Added the ability to pass the token from the options

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -6,7 +6,7 @@ const GithubApi = require('./github-api');
 exports.sourceNodes = async (context, pluginOptions) => {
   const { actions, createNodeId, createContentDigest, reporter } = context;
   const { createNode } = actions;
-  const { owner, repo } = pluginOptions;
+  const { owner, repo, token } = pluginOptions;
 
   assert(owner, 'owner options is required');
   assert(repo, 'repo options is required');


### PR DESCRIPTION
There's an issue with the current implementation of the token: it was added to the call to the Github API class init, but it's not being pulled from the Gatsby config options